### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const app = express();
 const server = http.createServer(app);
 const io = socketio(server);
 app.set('io', io); // Make io accessible in controllers
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 5000;
 
 // View engine
 app.set('views', path.join(__dirname, 'views'));


### PR DESCRIPTION
bug fixed.

todo:
fix the below error:
CastError: Cast to ObjectId failed for value "total-quantity" (type string) at path "_id" for model "Product"
    at SchemaObjectId.cast (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\schema\objectId.js:251:11)
    at SchemaType.applySetters (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\schemaType.js:1258:12)
    at SchemaType.castForQuery (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\schemaType.js:1694:17)
    at cast (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\cast.js:390:32)
    at Query.cast (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\query.js:5060:12)
    at Query._castConditions (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\query.js:2374:10)
    at model.Query._findOne (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\query.js:2697:8)
    at model.Query.exec (W:\Github\SIT725-2025-Wareniex\node_modules\mongoose\lib\query.js:4627:80)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) 
    at async exports.apiShow (W:\Github\SIT725-2025-Wareniex\controllers\productController.js:12:19)
